### PR TITLE
npm installation error

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {},
   "main" : "vcard.js",
-  "bin" : "./bin/vard-to-json.js",
+  "bin" : "./bin/vcard-to-json.js",
   "repository" : {
     "type": "git",
     "url": "git://github.com/jasperla/node-vcard.git"


### PR DESCRIPTION
Hi,

I had problems installing node-vcard via npm. I think a wrong path in package.json led to this error. The typo is now corrected. 
Could you please update the npm package?
